### PR TITLE
Add tournament probability calculator module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,6 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "pytest>=8.0.0",
+]

--- a/tournament/core.py
+++ b/tournament/core.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+
+@dataclass
+class Player:
+    name: str
+
+class Match:
+    def __init__(self, challenger: Player, defender: Player, num_games: int):
+        self.challenger = challenger
+        self.defender = defender
+        self.num_games = num_games
+
+    def prob_challenger_wins_match(self, p_challenger_wins_game: float) -> float:
+        """
+        Calculates probability that challenger wins the match.
+        For this tournament type, the challenger must win all games to win the match.
+        """
+        return p_challenger_wins_game ** self.num_games
+
+    def prob_defender_wins_match(self, p_challenger_wins_game: float) -> float:
+        """
+        Calculates probability that defender wins the match.
+        The defender retains their position (wins the match) if the challenger fails to win all games.
+        """
+        return 1.0 - self.prob_challenger_wins_match(p_challenger_wins_game)
+
+    def prob_match_length(self, length: int, p_challenger_wins_game: float, short_circuit_on_defender_win: bool = False) -> float:
+        """
+        Calculates the probability that the match lasts exactly `length` games.
+
+        Args:
+            length: The number of games.
+            p_challenger_wins_game: Probability challenger wins a single game.
+            short_circuit_on_defender_win: If True, match ends immediately if defender wins a game.
+                                           (Because challenger needs to win ALL games, so one loss makes it impossible).
+        """
+        if not short_circuit_on_defender_win:
+            # If no short circuit, match always lasts num_games (unless we define other rules, but for now fixed length)
+            # Assuming fixed length unless short circuit.
+            return 1.0 if length == self.num_games else 0.0
+
+        # With short circuit on defender win:
+        # Match ends at game k < num_games if:
+        #   Challenger won games 1 to k-1 (prob p^(k-1))
+        #   AND Defender wins game k (prob 1-p)
+        # Match ends at game num_games if:
+        #   Challenger won games 1 to num_games-1 (prob p^(n-1))
+        #   (The result of the last game doesn't matter for length, it ends anyway)
+
+        if length < 1 or length > self.num_games:
+            return 0.0
+
+        if length < self.num_games:
+            # Ends early implies defender won this specific game, and challenger won previous ones.
+            return (p_challenger_wins_game ** (length - 1)) * (1.0 - p_challenger_wins_game)
+
+        if length == self.num_games:
+            # Reached the end. Means challenger won all previous n-1 games.
+            return p_challenger_wins_game ** (self.num_games - 1)
+
+        return 0.0

--- a/tournament/main.py
+++ b/tournament/main.py
@@ -1,0 +1,113 @@
+import sys
+import os
+
+# Ensure the project root is in sys.path so we can import from tournament
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from tournament.core import Player, Match
+
+def calculate_probabilities():
+    # Define players
+    bo = Player(name="Bo")
+    ci = Player(name="Ci")
+    al = Player(name="Al")
+
+    # Probabilities
+    p_bo_beats_ci = 0.6
+    p_ci_beats_bo = 1.0 - p_bo_beats_ci # 0.4
+
+    p_al_beats_bo = 0.5
+    p_bo_beats_al = 1.0 - p_al_beats_bo # 0.5
+
+    p_al_beats_ci = 0.7
+    p_ci_beats_al = 1.0 - p_al_beats_ci # 0.3
+
+    # Define Matches
+    # Round 1: Bo vs Ci. 2 games. condition: win both.
+    match_r1 = Match(challenger=bo, defender=ci, num_games=2)
+
+    # Round 2 (if Bo wins R1): Bo vs Al. 2 games. condition: win both. Short circuit if Al wins G1.
+    match_r2_bo = Match(challenger=bo, defender=al, num_games=2)
+
+    # Round 2 (if Ci wins R1): Ci vs Al. 2 games. condition: win both. Short circuit if Al wins G1.
+    match_r2_ci = Match(challenger=ci, defender=al, num_games=2)
+
+    # 1. A priori probabilities
+
+    # (b) Bo will win the first round.
+    # Bo wins R1 if Bo wins both games against Ci.
+    prob_bo_wins_r1 = match_r1.prob_challenger_wins_match(p_bo_beats_ci)
+
+    # Ci will win the first round.
+    # Ci is the defender in match_r1 context but logic is symmetric.
+    # Ci wins R1 if Ci wins both games against Bo.
+    prob_ci_wins_r1 = p_ci_beats_bo ** 2
+
+    # (a) The second round will be required.
+    # Required if Bo wins R1 OR Ci wins R1. Mutually exclusive?
+    # Bo wins 2 games -> Bo wins R1.
+    # Ci wins 2 games -> Ci wins R1.
+    # 1-1 split -> Neither wins R1.
+    # So yes, mutually exclusive because one cannot both win 2 games in a 2-game match.
+    prob_2nd_round_req = prob_bo_wins_r1 + prob_ci_wins_r1
+
+    # (c) Al will retain his championship this year.
+    # Al retains if R2 is NOT required OR (R2 required AND Challenger loses R2).
+    # P(Al retains) = 1 - P(Challenger wins championship)
+    # Challenger wins championship if (Bo wins R1 AND Bo wins R2) OR (Ci wins R1 AND Ci wins R2)
+    prob_bo_champ = prob_bo_wins_r1 * match_r2_bo.prob_challenger_wins_match(p_bo_beats_al)
+    prob_ci_champ = prob_ci_wins_r1 * match_r2_ci.prob_challenger_wins_match(p_ci_beats_al)
+    prob_al_champ = 1.0 - (prob_bo_champ + prob_ci_champ)
+
+    print(f"1(a) P(2nd Round Req) = {prob_2nd_round_req:.4f}")
+    print(f"1(b) P(Bo Wins 1st Round) = {prob_bo_wins_r1:.4f}")
+    print(f"1(c) P(Al Champ) = {prob_al_champ:.4f}")
+
+    # 2. Conditional probabilities given 2nd round is required
+
+    # (a) Bo is the surviving challenger.
+    # P(Bo Wins R1 | 2nd Round Req) = P(Bo Wins R1 AND 2nd Round Req) / P(2nd Round Req)
+    # Since Bo Wins R1 implies 2nd Round Req, numerator is P(Bo Wins R1)
+    prob_bo_challenger_given_r2 = prob_bo_wins_r1 / prob_2nd_round_req
+
+    # For calculation of (b), we also need P(Ci Challenger | 2nd Round Req)
+    prob_ci_challenger_given_r2 = prob_ci_wins_r1 / prob_2nd_round_req
+
+    print(f"2(a) P(Bo Challenger | 2nd Round Req) = {prob_bo_challenger_given_r2:.4f}")
+
+    # (b) Al retains his championship.
+    # P(Al Champ | 2nd Round Req)
+    # = P(Al Champ AND 2nd Round Req) / P(2nd Round Req)
+    # Al Champ AND 2nd Round Req means:
+    # (Bo Wins R1 AND Bo loses R2) OR (Ci Wins R1 AND Ci loses R2)
+    prob_bo_wins_r1_and_loses_r2 = prob_bo_wins_r1 * (1.0 - match_r2_bo.prob_challenger_wins_match(p_bo_beats_al))
+    prob_ci_wins_r1_and_loses_r2 = prob_ci_wins_r1 * (1.0 - match_r2_ci.prob_challenger_wins_match(p_ci_beats_al))
+
+    prob_al_champ_given_r2 = (prob_bo_wins_r1_and_loses_r2 + prob_ci_wins_r1_and_loses_r2) / prob_2nd_round_req
+
+    print(f"2(b) P(Al Champ | 2nd Round Req) = {prob_al_champ_given_r2:.4f}")
+
+    # 3. Given that the second round was required and that it comprised only one game, what is the conditional probability that it was Bo who won the first round?
+    # P(Bo Challenger | 2nd Round Req AND R2 Length == 1)
+    # = P(Bo Challenger AND R2 Length == 1) / P(2nd Round Req AND R2 Length == 1)
+    # Note: "2nd Round Req" is implied by "R2 Length == 1" (can't have length 1 if not required).
+    # Actually, be careful. "R2 Length == 1" implies R2 happened.
+
+    # Numerator: Bo Challenger (Bo Wins R1) AND R2 Length == 1 (in Bo vs Al match)
+    # R2 Length == 1 means Al wins the first game.
+    # P(Bo Wins R1) * P(R2 Length == 1 | Bo Challenger)
+    # match_r2_bo length 1: Al wins G1.
+    prob_r2_bo_len_1 = match_r2_bo.prob_match_length(1, p_bo_beats_al, short_circuit_on_defender_win=True)
+    prob_numerator = prob_bo_wins_r1 * prob_r2_bo_len_1
+
+    # Denominator: P(R2 Length == 1)
+    # = P(Bo Challenger AND R2 Bo Length 1) + P(Ci Challenger AND R2 Ci Length 1)
+    prob_r2_ci_len_1 = match_r2_ci.prob_match_length(1, p_ci_beats_al, short_circuit_on_defender_win=True)
+    prob_denominator = (prob_bo_wins_r1 * prob_r2_bo_len_1) + (prob_ci_wins_r1 * prob_r2_ci_len_1)
+
+    prob_q3 = prob_numerator / prob_denominator
+
+    print(f"3. P(Bo Challenger | 2nd Round Req AND One Game) = {prob_q3:.4f}")
+
+if __name__ == "__main__":
+    calculate_probabilities()

--- a/tournament/tests/test_core.py
+++ b/tournament/tests/test_core.py
@@ -1,0 +1,116 @@
+import pytest
+from tournament.core import Player, Match
+
+def test_match_win_probability():
+    p1 = Player("P1")
+    p2 = Player("P2")
+    match = Match(p1, p2, num_games=2)
+
+    # p = 0.5. Win all 2 games = 0.25
+    assert match.prob_challenger_wins_match(0.5) == 0.25
+    assert match.prob_defender_wins_match(0.5) == 0.75
+
+    # p = 1.0. Win all 2 = 1.0
+    assert match.prob_challenger_wins_match(1.0) == 1.0
+    assert match.prob_defender_wins_match(1.0) == 0.0
+
+    # p = 0.0. Win all 2 = 0.0
+    assert match.prob_challenger_wins_match(0.0) == 0.0
+    assert match.prob_defender_wins_match(0.0) == 1.0
+
+def test_match_length_no_short_circuit():
+    p1 = Player("P1")
+    p2 = Player("P2")
+    match = Match(p1, p2, num_games=3)
+
+    # Without short circuit, length is always num_games
+    assert match.prob_match_length(3, 0.5, short_circuit_on_defender_win=False) == 1.0
+    assert match.prob_match_length(2, 0.5, short_circuit_on_defender_win=False) == 0.0
+
+def test_match_length_with_short_circuit():
+    p1 = Player("P1")
+    p2 = Player("P2")
+    match = Match(p1, p2, num_games=2)
+
+    # Short circuit on defender win (defender wins game -> match ends)
+    # p_challenger = 0.6
+    # p_defender = 0.4
+
+    # Length 1: Defender wins G1. Prob 0.4.
+    assert match.prob_match_length(1, 0.6, short_circuit_on_defender_win=True) == pytest.approx(0.4)
+
+    # Length 2: Challenger wins G1 (0.6). Match continues.
+    # It ends at 2 regardless of G2 outcome (because num_games=2).
+    # So Prob = 0.6.
+    assert match.prob_match_length(2, 0.6, short_circuit_on_defender_win=True) == pytest.approx(0.6)
+
+    # Sum should be 1.0
+    assert match.prob_match_length(1, 0.6, True) + match.prob_match_length(2, 0.6, True) == pytest.approx(1.0)
+
+def test_match_length_short_circuit_3_games():
+    p1 = Player("P1")
+    p2 = Player("P2")
+    match = Match(p1, p2, num_games=3)
+    p = 0.5
+
+    # Length 1: Def wins G1. (0.5)
+    assert match.prob_match_length(1, p, True) == 0.5
+
+    # Length 2: Chall wins G1 (0.5) * Def wins G2 (0.5) = 0.25
+    assert match.prob_match_length(2, p, True) == 0.25
+
+    # Length 3: Chall wins G1 (0.5) * Chall wins G2 (0.5) = 0.25. (Ends at 3)
+    assert match.prob_match_length(3, p, True) == 0.25
+
+    assert 0.5 + 0.25 + 0.25 == 1.0
+
+def test_chess_problem_regression():
+    # Verify the specific answers from the problem
+    bo = Player("Bo")
+    ci = Player("Ci")
+    al = Player("Al")
+
+    p_bo_beats_ci = 0.6
+    p_ci_beats_bo = 0.4 # implied
+
+    match_r1 = Match(bo, ci, 2)
+
+    # 1(a)
+    prob_bo_wins_r1 = match_r1.prob_challenger_wins_match(p_bo_beats_ci)
+    prob_ci_wins_r1 = p_ci_beats_bo ** 2
+    prob_2nd_round_req = prob_bo_wins_r1 + prob_ci_wins_r1
+    assert prob_2nd_round_req == pytest.approx(0.52)
+
+    # 1(b)
+    assert prob_bo_wins_r1 == pytest.approx(0.36)
+
+    # 1(c)
+    p_bo_beats_al = 0.5
+    p_ci_beats_al = 0.3
+    match_r2_bo = Match(bo, al, 2)
+    match_r2_ci = Match(ci, al, 2)
+
+    prob_bo_champ = prob_bo_wins_r1 * match_r2_bo.prob_challenger_wins_match(p_bo_beats_al)
+    prob_ci_champ = prob_ci_wins_r1 * match_r2_ci.prob_challenger_wins_match(p_ci_beats_al)
+    prob_al_champ = 1.0 - (prob_bo_champ + prob_ci_champ)
+
+    assert prob_al_champ == pytest.approx(0.8956)
+
+    # 2(a)
+    assert prob_bo_wins_r1 / prob_2nd_round_req == pytest.approx(0.6923, abs=1e-4)
+
+    # 2(b)
+    prob_bo_wins_r1_loses_r2 = prob_bo_wins_r1 * (1.0 - match_r2_bo.prob_challenger_wins_match(p_bo_beats_al))
+    prob_ci_wins_r1_loses_r2 = prob_ci_wins_r1 * (1.0 - match_r2_ci.prob_challenger_wins_match(p_ci_beats_al))
+    prob_al_champ_given_r2 = (prob_bo_wins_r1_loses_r2 + prob_ci_wins_r1_loses_r2) / prob_2nd_round_req
+
+    assert prob_al_champ_given_r2 == pytest.approx(0.7992, abs=1e-4)
+
+    # 3
+    prob_r2_bo_len_1 = match_r2_bo.prob_match_length(1, p_bo_beats_al, short_circuit_on_defender_win=True)
+    prob_r2_ci_len_1 = match_r2_ci.prob_match_length(1, p_ci_beats_al, short_circuit_on_defender_win=True)
+
+    prob_num = prob_bo_wins_r1 * prob_r2_bo_len_1
+    prob_den = (prob_bo_wins_r1 * prob_r2_bo_len_1) + (prob_ci_wins_r1 * prob_r2_ci_len_1)
+
+    assert prob_num / prob_den == pytest.approx(0.6164, abs=1e-4)


### PR DESCRIPTION
This PR adds a Python module for calculating tournament probabilities, focusing on a specific chess tournament problem but with generalized classes. It includes unit tests and is runnable as a CLI.


---
*PR created automatically by Jules for task [16487480728502686627](https://jules.google.com/task/16487480728502686627) started by @marcusholmgren*